### PR TITLE
arch-nspawn should not take pacman cache from host

### DIFF
--- a/arch-nspawn.in
+++ b/arch-nspawn.in
@@ -53,7 +53,11 @@ shift 1
 [[ -z $working_dir ]] && die 'Please specify a working directory.'
 
 if [[ -z $cache_dir ]]; then
-	cache_dirs=($(pacman -v 2>&1 | grep '^Cache Dirs:' | sed 's/Cache Dirs:\s*//g'))
+	if [[ -z $pac_conf ]]; then
+		cache_dirs=($(pacman --config "$working_dir/etc/pacman.conf" -v 2>&1 | grep '^Cache Dirs:' | sed 's/Cache Dirs:\s*//g'))
+	else
+		cache_dirs=($(pacman --config "$pac_conf" -v 2>&1 | grep '^Cache Dirs:' | sed 's/Cache Dirs:\s*//g'))
+	fi
 else
 	cache_dirs=("$cache_dir")
 fi


### PR DESCRIPTION
Previously, arch-nspawn was using the hosts' pacman cache in
the chroot even when the chroot was set up with a different
cache by mkarchroot, unless specified with the -c flag.
Problem is that makechrootpkg passes no -C, -M nor -c flags
to arch-nspawn, so all values must be obtained from the
working directory.

This change take the cache directories from the pacman.conf
specified with the -C option unless the -c option was given
(as is the case when the chroot is set up with mkarchroot),
and, when neither -C nor -c is given (as is the case when
invoked by makechrootpkg), the cache directory is taken
from the pacman.conf in the working directory.

This wasn't such an issue when i686 was mainline, however,
which building packages in a chroot against archlinux32 on
an x86_64 platform, the cache of the host should _never_ be
used.